### PR TITLE
fix: oncePerFixture hook is not executed after tests if last test is skipped(closes #7)

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ class Helper {
 
     static shouldExecuteFixtureHook (t) {
         const test      = t.testRun.test;
-        const tests     = test.fixture.testFile.collectedTests.filter(item => item.fixture === test.fixture);
+        const tests     = test.fixture.testFile.collectedTests
+            .filter(item => item.fixture === test.fixture && !item.skip);
         const testIndex = tests.indexOf(test);
 
         const isInFixtureBeforeEachHook = t.testRun.phase === 'inFixtureBeforeEachHook';


### PR DESCRIPTION
closes https://github.com/DevExpress/testcafe-once-hook/issues/7